### PR TITLE
Replace hard-coded CSP 'self' values with csp.SELF enum

### DIFF
--- a/gpx_routes/settings.py
+++ b/gpx_routes/settings.py
@@ -14,6 +14,7 @@ import os
 from pathlib import Path
 
 import dj_database_url
+from django.middleware.security import csp
 from dotenv import load_dotenv
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -144,11 +145,11 @@ MEDIA_URL = "/media/"
 # Content Security Policy - Allow images from CDN
 SECURE_CONTENT_SECURITY_POLICY = {
     "img-src": [
-        "'self'",
+        csp.SELF,
         "https://files.smithdc.uk",
         "https://s3.us-east-005.backblazeb2.com",
     ],
-    "default-src": ["'self'"],
+    "default-src": [csp.SELF],
 }
 
 


### PR DESCRIPTION
Use the django.middleware.security.csp.SELF constant instead of
hard-coded "'self'" strings in the Content Security Policy configuration.
This makes the code more maintainable and follows Django best practices.