### PR TITLE
Fix CSP import to use correct Django 6.0 module path

### DIFF
--- a/gpx_routes/settings.py
+++ b/gpx_routes/settings.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 
 import dj_database_url
-from django.middleware.security import csp
+from django.utils.csp import CSP
 from dotenv import load_dotenv
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -145,11 +145,11 @@ MEDIA_URL = "/media/"
 # Content Security Policy - Allow images from CDN
 SECURE_CONTENT_SECURITY_POLICY = {
     "img-src": [
-        csp.SELF,
+        CSP.SELF,
         "https://files.smithdc.uk",
         "https://s3.us-east-005.backblazeb2.com",
     ],
-    "default-src": [csp.SELF],
+    "default-src": [CSP.SELF],
 }
 
 


### PR DESCRIPTION
The previous PR used the incorrect import path
`from django.middleware.security import csp` which caused an ImportError.

The correct import in Django 6.0 is:
`from django.utils.csp import CSP`

This commit fixes the import and updates all references from csp.SELF to CSP.SELF to match Django 6.0's CSP enum implementation.